### PR TITLE
Device needs to be opened before setting options

### DIFF
--- a/SigrokCLI.java
+++ b/SigrokCLI.java
@@ -240,6 +240,9 @@ class SigrokCLI
             /* Use first device found. */
             device = devices.get(0);
 
+            /* Open it */
+            device.open();
+
             /* Apply device settings from command line. */
             Map<ConfigKey, String> options = new HashMap<ConfigKey, String>();
             options.put(ConfigKey.getLIMIT_MSEC(), "time");


### PR DESCRIPTION
For example saleae-logic16 checks in config_set that sdi->status == SR_ST_ACTIVE.

sigrok-cli does sr_dev_open() before setting any options, so Java version should do the same.
